### PR TITLE
Fixed GitLab workspace integration

### DIFF
--- a/src/services/providers/gitlabWorkspaceProvider.js
+++ b/src/services/providers/gitlabWorkspaceProvider.js
@@ -106,6 +106,8 @@ export default new Provider({
     return gitlabHelper.getTree({
       ...store.getters['workspace/currentWorkspace'],
       token: this.getToken(),
+      existingBody: [],
+      page: 1,
     });
   },
   prepareChanges(tree) {


### PR DESCRIPTION
Changed getTree to a recursive function so it iterates through all pages of the GitLab API's response when fetching the tree.